### PR TITLE
Fix site url

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -1,6 +1,6 @@
 site:
   title: Neo4j Query API
-  url: https://neo4j.com/docs/query-api/
+  url: https://neo4j.com/docs/
   start_page: query-api:ROOT:index.adoc
 
 content:


### PR DESCRIPTION
url value needs to be `https://neo4j.com/docs/` for canonicals