### PR TITLE
Introduce `resultAvailableAfter` and `resultConsumedAfter` to QueryAPI

### DIFF
--- a/modules/ROOT/pages/bookmarks.adoc
+++ b/modules/ROOT/pages/bookmarks.adoc
@@ -35,7 +35,9 @@ All responses include a `bookmarks` field containing a list of encoded bookmarks
   "bookmarks": [
     "FB:kcwQ/wTfJf8rS1WY+GiIKXsCXgmQ"
   ],
-  "queryType": "rw"
+  "queryType": "rw",
+  "resultAvailableAfter": 10,
+  "resultConsumedAfter": 25
 }
 ----
 

--- a/modules/ROOT/pages/impersonation.adoc
+++ b/modules/ROOT/pages/impersonation.adoc
@@ -49,7 +49,9 @@ Content-Type: application/json
   "bookmarks": [
     "FB:kcwQ/wTfJf8rS1WY+GiIKXsCXgyQ"
   ],
-  "queryType": "r"
+  "queryType": "r",
+  "resultAvailableAfter": 10,
+  "resultConsumedAfter": 25
 }
 ----
 ====

--- a/modules/ROOT/pages/plain-json.adoc
+++ b/modules/ROOT/pages/plain-json.adoc
@@ -86,7 +86,9 @@ Content-Type: application/json
   "bookmarks": [
     "FB:kcwQ/wTfJf8rS1WY+GiIKXsCXg6Q"
   ],
-  "queryType": "rw"
+  "queryType": "rw",
+  "resultAvailableAfter": 10,
+  "resultConsumedAfter": 25
 }
 ----
 

--- a/modules/ROOT/pages/profile-query.adoc
+++ b/modules/ROOT/pages/profile-query.adoc
@@ -117,7 +117,9 @@ Content-Type: application/json
   "bookmarks": [
     "FB:kcwQC685m8YsRuyUSvMWiiQriwKQ"
   ],
-  "queryType": "r"
+  "queryType": "r",
+  "resultAvailableAfter": 10,
+  "resultConsumedAfter": 25
 }
 ----
 ====

--- a/modules/ROOT/pages/query-counters.adoc
+++ b/modules/ROOT/pages/query-counters.adoc
@@ -66,7 +66,9 @@ Content-Type: application/json
   "bookmarks": [
     "FB:kcwQaCYpl4jjRRiD7NlEZ0YJ9MkB8pA="
   ],
-  "queryType": "rw"
+  "queryType": "rw",
+  "resultAvailableAfter": 10,
+  "resultConsumedAfter": 25
 }
 ----
 ====

--- a/modules/ROOT/pages/query.adoc
+++ b/modules/ROOT/pages/query.adoc
@@ -91,7 +91,7 @@ For example, using an `elementId` to `MATCH` an element across different transac
 For more information, see xref:bookmarks.adoc[].
 <6> Type of query executed: read only (`"r"`), read write (`"rw"`), write only (`"w"`) and schema write (`"s"`). label:new[Introduced in 2026.07]
 <7> Elapsed time in milliseconds for result be available to be consumed label:new[Introduced in 2026.07]
-<8> Elapsed time in milliseconds for consume the result. label:new[Introduced in 2026.07]
+<8> Elapsed time in milliseconds to consume the result. label:new[Introduced in 2026.07]
 
 ====
 

--- a/modules/ROOT/pages/query.adoc
+++ b/modules/ROOT/pages/query.adoc
@@ -73,7 +73,9 @@ Content-Type: application/json
   "bookmarks": [  // <5>
     "FB:kcwQ/wTfJf8rS1WY+GiIKXsCXgmQ"
   ],
-  "queryType": "rw" // <6>
+  "queryType": "rw", // <6>
+  "resultAvailableAfter": 10, // <7>
+  "resultConsumedAfter": 25 // <8>
 }
 ----
 
@@ -88,6 +90,8 @@ For example, using an `elementId` to `MATCH` an element across different transac
 <5> Bookmarks are used to enforce an ordering to transactions. +
 For more information, see xref:bookmarks.adoc[].
 <6> Type of query executed: read only (`"r"`), read write (`"rw"`), write only (`"w"`) and schema write (`"s"`). label:new[Introduced in 2026.07]
+<7> Elapsed time in milliseconds for result be available to be consumed label:new[Introduced in 2026.07]
+<8> Elapsed time in milliseconds for consume the result. label:new[Introduced in 2026.07]
 
 ====
 
@@ -262,7 +266,9 @@ Content-Type: application/json
   "bookmarks": [
     "FB:kcwQ/wTfJf8rS1WY+GiIKXsCXgmQ"
   ],
-  "queryType": "rw"
+  "queryType": "rw",
+  "resultAvailableAfter": 10,
+  "resultConsumedAfter": 25
 }
 ----
 ====

--- a/modules/ROOT/pages/routing.adoc
+++ b/modules/ROOT/pages/routing.adoc
@@ -66,7 +66,9 @@ Content-Type: application/json
   "bookmarks": [
     "FB:kcwQ/wTfJf8rS1WY+GiIKXsCXguQ"
   ],
-  "queryType": "r"
+  "queryType": "r",
+  "resultAvailableAfter": 10,
+  "resultConsumedAfter": 25
 }
 ----
 ====

--- a/modules/ROOT/pages/streaming.adoc
+++ b/modules/ROOT/pages/streaming.adoc
@@ -205,7 +205,7 @@ The `Summary` event marks the end of the stream and provides metadata about the 
 * `profiledQueryPlan` (optional) -- Detailed execution metrics, if the query was run with profiling enabled. See xref:profile-query.adoc[].
 * `queryType` (optional) -- Type of query executed: read only (`"r"`), read write (`"rw"`), write only (`"w"`) and schema write (`"s"`). label:new[Introduced in 2026.07]
 * `resultAvailableAfter` (optional) -- Elapsed time in milliseconds for result be available to be consumed label:new[Introduced in 2026.07]
-* `resultConsumedAfter` (optional) -- Elapsed time in milliseconds for consume the result. label:new[Introduced in 2026.07]
+* `resultConsumedAfter` (optional) -- Elapsed time in milliseconds to consume the result. label:new[Introduced in 2026.07]
 
 
 [[event-error]]

--- a/modules/ROOT/pages/streaming.adoc
+++ b/modules/ROOT/pages/streaming.adoc
@@ -77,7 +77,7 @@ Summary
 {"$event":"Header","_body":{"fields":["name","age"]}}
 {"$event":"Record","_body": ["Alice",32]}
 {"$event":"Record","_body": ["Bob",29]}
-{"$event":"Summary","_body":{"bookmarks":["FB:kcwQ/wTfJf8rS1WY+GiIKXsCXgmQ"],"queryType": "r"}}
+{"$event":"Summary","_body":{"bookmarks":["FB:kcwQ/wTfJf8rS1WY+GiIKXsCXgmQ"],"queryType": "r","resultAvailableAfter": 10,"resultConsumedAfter": 25}}
 ----
 ======
 =====
@@ -190,7 +190,9 @@ The `Summary` event marks the end of the stream and provides metadata about the 
     "notifications": [ /* notifications structure */ ],"counters": { /* counters structure */},
     "queryPlan": { /* query plan structure */ },
     "profiledQueryPlan": { /* profiled query plan structure */ },
-    "queryType": "r"
+    "queryType": "r",
+    "resultAvailableAfter": 10,
+    "resultConsumedAfter": 25
   }
 }
 ----
@@ -202,6 +204,8 @@ The `Summary` event marks the end of the stream and provides metadata about the 
 * `queryPlan` (optional) -- The logical query plan. See xref:profile-query.adoc[].
 * `profiledQueryPlan` (optional) -- Detailed execution metrics, if the query was run with profiling enabled. See xref:profile-query.adoc[].
 * `queryType` (optional) -- Type of query executed: read only (`"r"`), read write (`"rw"`), write only (`"w"`) and schema write (`"s"`). label:new[Introduced in 2026.07]
+* `resultAvailableAfter` (optional) -- Elapsed time in milliseconds for result be available to be consumed label:new[Introduced in 2026.07]
+* `resultConsumedAfter` (optional) -- Elapsed time in milliseconds for consume the result. label:new[Introduced in 2026.07]
 
 
 [[event-error]]

--- a/modules/ROOT/pages/transactions.adoc
+++ b/modules/ROOT/pages/transactions.adoc
@@ -121,7 +121,7 @@ For more information, see xref:bookmarks.adoc[].
 Use the ID for subsequent request URIs.
 <.> Type of query executed: read only (`"r"`), read write (`"rw"`), write only (`"w"`) and schema write (`"s"`). label:new[Introduced in 2026.07]
 <.> Elapsed time in milliseconds for result be available to be consumed label:new[Introduced in 2026.07]
-<.> Elapsed time in milliseconds for consume the result. label:new[Introduced in 2026.07]
+<.> Elapsed time in milliseconds to consume the result. label:new[Introduced in 2026.07]
 ====
 
 

--- a/modules/ROOT/pages/transactions.adoc
+++ b/modules/ROOT/pages/transactions.adoc
@@ -99,7 +99,9 @@ neo4j-cluster-affinity: MTAuOC41Ljc6MTc0NzQ=  // <2>
     "id": "lyU",
     "expires": "2024-10-22T15:48:29Z"
   },
-  "queryType": "rw"  // <8>
+  "queryType": "rw",  // <8>
+  "resultAvailableAfter": 10, // <9>
+  "resultConsumedAfter": 25 // <10>
 }
 ----
 
@@ -118,6 +120,8 @@ For more information, see xref:bookmarks.adoc[].
 <.> Transaction information.
 Use the ID for subsequent request URIs.
 <.> Type of query executed: read only (`"r"`), read write (`"rw"`), write only (`"w"`) and schema write (`"s"`). label:new[Introduced in 2026.07]
+<.> Elapsed time in milliseconds for result be available to be consumed label:new[Introduced in 2026.07]
+<.> Elapsed time in milliseconds for consume the result. label:new[Introduced in 2026.07]
 ====
 
 
@@ -196,7 +200,9 @@ Content-Type: application/json
     "id": "lyU",
     "expires": "2024-10-22T15:48:29Z"
   },
-  "queryType": "rw"
+  "queryType": "rw",
+  "resultAvailableAfter": 10,
+  "resultConsumedAfter": 25
 }
 ----
 ====
@@ -381,7 +387,9 @@ neo4j-cluster-affinity: MTAuOC41Ljc6MTc0NzQ=
     "id": "lyU",
     "expires": "2024-10-22T15:48:29Z"
   },
-  "queryType": "rw"
+  "queryType": "rw",
+  "resultAvailableAfter": 10,
+  "resultConsumedAfter": 25
 }
 ----
 ====

--- a/modules/ROOT/pages/typed-json.adoc
+++ b/modules/ROOT/pages/typed-json.adoc
@@ -121,7 +121,9 @@ Content-Type: application/vnd.neo4j.query.v1.1
   "bookmarks": [
     "FB:kcwQ/wTfJf8rS1WY+GiIKXsCXg6Q"
   ],
-  "queryType": "rw"
+  "queryType": "rw",
+  "resultAvailableAfter": 10,
+  "resultConsumedAfter": 25
 }
 ----
 


### PR DESCRIPTION
This values holds the time in milliseconds that the QueryAPI took to get the result available and to consume it.

This is part of an effort to make QueryAPI in pair with the Bolt Driver.

Those will be introduced in 2026.07.